### PR TITLE
chore(deps): add Dependabot for Nix flake, disable Renovate nix manager

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  # Renovate's nix manager cannot update flake.lock on Mend-hosted infrastructure:
+  # it requires running `nix flake update` (to compute narHash values), but the
+  # sandboxed jr-microvm environment has no nix binary and allowedCommands is locked
+  # to git add/reset/pwd only. Every Monday run ends with "Digest is not updated" →
+  # level-40 "Error updating branch: update failure". Dependabot handles flake.lock
+  # instead; the nix manager is disabled in renovate.json.
+  - package-ecosystem: "nix"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "02:00"
+      timezone: "UTC"
+    groups:
+      nix-flake-inputs:
+        patterns:
+          - "*"

--- a/flake.nix
+++ b/flake.nix
@@ -67,10 +67,7 @@
               renovate-config-validator = {
                 enable = true;
                 name = "Renovate config validator";
-                entry = "${pkgs.writeShellScript "validate-renovate" ''
-                  if [ -n "''${NIX_BUILD_TOP:-}" ]; then exit 0; fi
-                  ${pkgs.nodejs}/bin/npx --yes --package renovate -- renovate-config-validator "$@"
-                ''}";
+                entry = "${pkgs.renovate}/bin/renovate-config-validator";
                 files = "renovate\\.json$";
                 language = "system";
                 pass_filenames = true;

--- a/flake.nix
+++ b/flake.nix
@@ -72,6 +72,14 @@
                 language = "system";
                 pass_filenames = true;
               };
+              dependabot-validator = {
+                enable = true;
+                name = "Dependabot config validator";
+                entry = "${pkgs.check-jsonschema}/bin/check-jsonschema --builtin-schema vendor.dependabot";
+                files = "\\.github/dependabot\\.yml$";
+                language = "system";
+                pass_filenames = true;
+              };
             };
             tools = pkgs;
             excludes = [

--- a/renovate.json
+++ b/renovate.json
@@ -11,7 +11,7 @@
   "semanticCommits": "enabled",
   "rangeStrategy": "bump",
   "pinDigests": true,
-  "nix": { "enabled": true },
+  "nix": { "enabled": false },
   "vulnerabilityAlerts": {
     "enabled": true,
     "labels": ["security"],
@@ -24,21 +24,6 @@
       "groupName": "github-actions",
       "pinDigests": true,
       "commitMessageTopic": "GitHub Actions"
-    },
-    {
-      "matchManagers": ["nix"],
-      "groupName": "nix flake updates",
-      "commitMessageTopic": "Nix flake inputs"
-    },
-    {
-      "description": "Expedite nix security updates — bypass weekly schedule",
-      "matchManagers": ["nix"],
-      "matchJsonata": ["$exists(vulnerabilityFixVersion)"],
-      "schedule": ["at any time"],
-      "automerge": true,
-      "labels": ["security"],
-      "groupName": "nix security updates",
-      "commitMessageTopic": "Nix security updates"
     },
     {
       "matchManagers": ["npm"],


### PR DESCRIPTION
## Summary

- Add `.github/dependabot.yml` with `package-ecosystem: nix` to update `flake.lock` inputs via Dependabot
- Disable Renovate's nix manager (`"nix": { "enabled": false }`) and remove its two nix `packageRules` blocks; Renovate continues handling github-actions and npm
- Add `dependabot-validator` pre-commit hook: `check-jsonschema --builtin-schema vendor.dependabot` (from `pkgs.check-jsonschema` 0.37.2, no network required at run time)
- Fix pre-existing `renovate-config-validator` pre-commit hook (`npx` invocation returned exit 127 in pre-commit's env; now uses `pkgs.renovate` directly from nixpkgs)

## Background

Renovate's `nix` manager **cannot update `flake.lock` on Mend-hosted infrastructure**. It requires running `nix flake update` to regenerate `flake.lock` (the lock file stores `narHash` values — a bare commit SHA is not valid). The Mend microVM (`jr-microvm`) has no `nix` binary available (`binarySource: "install"` fails for nix) and `allowedCommands` is restricted to `git add --all`, `git reset`, `pwd`.

Every Monday Renovate job since PR #84 (2026-04-24, which deleted the DeterminateSystems cron workflow and added `renovate.json`) has ended with:
```
"Digest is not updated"  depName=nixpkgs  expectedValue=0e2e6bcf...
"Error updating branch: update failure"  (level=40)
```

**This is a pilot PR** to verify that Dependabot's `nix` ecosystem support (released 2026-04-07) correctly handles `flake.lock` updates and that the `groups:` option produces a single grouped PR. If confirmed, the same pattern rolls out to all other repos.